### PR TITLE
Add Per-row [All] buttons to Mass Gem Send menu

### DIFF
--- a/RoA-QoL.user.js
+++ b/RoA-QoL.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         RoA-QoL
 // @namespace    Reltorakii_is_awesome
-// @version      2.9.6
+// @version      2.9.7
 // @description  try to take over the world!
 // @author       Reltorakii
 // @icon         https://cdn.jsdelivr.net/gh/edvordo/roa-qol@2.8.4/resources/img/logo-32.png
@@ -9,7 +9,7 @@
 // @match        http://*.avabur.com/game*
 // @resource     QoLCSS             https://cdn.jsdelivr.net/gh/edvordo/roa-qol@2.8.6/resources/css/qol.css
 // @resource     QoLHeaderHTML      https://cdn.jsdelivr.net/gh/edvordo/roa-qol@2.9.5/resources/templates/header.html
-// @resource     QoLSettingsHTML    https://cdn.jsdelivr.net/gh/edvordo/roa-qol@2.9.3/resources/templates/settings.html
+// @resource     QoLSettingsHTML    https://cdn.jsdelivr.net/gh/edvordo/roa-qol@2.9.7/resources/templates/settings.html
 // @resource     SpectrumCSS        https://cdnjs.cloudflare.com/ajax/libs/spectrum/1.8.0/spectrum.min.css
 // @resource     favicon.ico        https://cdn.jsdelivr.net/gh/edvordo/roa-qol@2.8.8/resources/img/favicon.ico
 // @require      https://cdn.jsdelivr.net/gh/edvordo/roa-qol@2.9.0/common.js
@@ -2266,7 +2266,7 @@
                             fn.__.addMassGemSendAllByRowButton(table);
                         }
                     }, 100);
-                    
+
                     setTimeout(() => clearInterval(checkForTable), 5000);
                 },
 

--- a/RoA-QoL.user.js
+++ b/RoA-QoL.user.js
@@ -2197,35 +2197,21 @@
                 },
 
                 addMassGemSendAllByRowButton(table) {
-                    const rows = table.querySelectorAll('tr');
-                    
-                    // skip the last row cuz that's the send button
-                    // also note that the Select All button at the top of the menu is not part of the table
-                    for (let i = 0; i < rows.length - 1; i++) {
-                        const row = rows[i];
-                        const cell = row.querySelector('td');
-                        
-                        if (cell) {
-                            // Add [All] button to the end of the cell content
-                            let a         = document.createElement('a');
-                            a.textContent = '[All]';
+                    const allButtonTemplate = document.createElement('a');
+                    allButtonTemplate.classList.add('RoAQoL-massGemSendRowAll');
+                    allButtonTemplate.textContent = '[All]';
 
-                            // make the [All] button set the value of the input field to the number of gems
-                            a.setAttribute('data-max', cell.firstChild.getAttribute('data-max')); // using cell.firstChild is probably bad practice
-                            a.setAttribute('class', 'RoAQoL-massGemSendRowAll');
-                            a.addEventListener('click', function (e) {
-                                e.preventDefault();
-                                let max = parseInt(this.getAttribute('data-max'));
-                                // theoretically impossible, but just in case
-                                if (isNaN(max) || max < 0) {
-                                    max = 0;
-                                }
-                                cell.firstChild.setAttribute('value', max);
-                            });
-                            cell.appendChild(document.createTextNode(' '));
-                            cell.appendChild(a);
-                        }
-                    }
+                    [...table.querySelectorAll('tr td')]
+                      .forEach(cell => {
+                          if (false === cell.innerHTML.includes('mass_gem_send_amount')) {
+                              return;
+                          }
+
+                          const allButton = allButtonTemplate.cloneNode(true);
+
+                          cell.insertAdjacentText('beforeend', ' ');
+                          cell.insertAdjacentElement('beforeend', allButton);
+                      });
                 },
 
                 startup() {
@@ -3205,6 +3191,20 @@ You can buy ${computed.can_buy} more crystals for <span class="gold">${computed.
     $(document).on('click', '#inventoryEquipmentTable .scrapLink', function(e) {
         if (e.originalEvent.altKey) {
             setTimeout(() => document.querySelector('#confirmButtons .green').click(), 200);
+        }
+    });
+
+    $(document).on('click', '.RoAQoL-massGemSendRowAll', function(e) {
+        const input = e.target.closest('td').querySelector('.mass_gem_send_amount');
+        // just in case
+        if (!input) {
+            return;
+        }
+
+        const max = parseInt(input.dataset.max);
+        // just in case
+        if (max) {
+            input.value = input.dataset.max;
         }
     });
 

--- a/resources/templates/settings.html
+++ b/resources/templates/settings.html
@@ -98,6 +98,9 @@
                 <input type="checkbox" class="qol-setting" data-key="fame_own_gems"> Add [Fame Own] gem button
             </label>
             <label class="col-lg-6 col-md-12 col-sm-6">
+                <input type="checkbox" class="qol-setting" data-key="mass_gem_send_all_by_row"> Add [All] buttons to mass gem send menu rows
+            </label>
+            <label class="col-lg-6 col-md-12 col-sm-6">
                 <input type="checkbox" class="qol-setting" data-key="export_ingredients"> Prepare export of ingredients for <a class="profileLink">Bento</a>s' Sheets
             </label>
         </div>


### PR DESCRIPTION
### Note: I'm not sure how the versioning system works and this really isn't a major feature so I left it at 2.9.6

### Code summary:
- On Click event listener reacts to Mass Send button `#massGemSend` being clicked, calls `massGemSendHandler()`
- `massGemSendHandler()` checks if this feature is enabled, then gets the Mass Gem Send Table, and sends it to `addMassGemSendAllByRowButton()`
- `addMassGemSendAllByRowButton()` adds an [All] button to the end of each row, and sets an On Click event listener to fill the input field with the max number of gems for that row

<img width="558" height="343" alt="image" src="https://github.com/user-attachments/assets/1603a7d6-5873-4479-9c1b-6cfb4a2dc312" />

- This is toggleable from QoL Hub > Settings > Inventory
<img width="636" height="161" alt="image" src="https://github.com/user-attachments/assets/015f89ae-0c31-4e8c-a5b0-c46ae21dbb9c" />
